### PR TITLE
Bumps to googleapis: ^2.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/en30/hubot-googleapi",
   "dependencies": {
-    "googleapis": "^1.0.14"
+    "googleapis": "^2.1.6"
   }
 }


### PR DESCRIPTION
 I do this because 1.0.14 has a missmatch between the name of the
 dataflow js file (v1beta3.js) and the name of the top level object
 inside the file (v1b3).
